### PR TITLE
async removed from tests; fixed README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,33 +10,48 @@ Promptrix is a prompt layout engine for Large Language Models.
     from promptrix.AssistantMessage import AssistantMessage
     from promptrix.ConversationHistory import ConversationHistory
 
-    functions = FunctionRegistry()
-    tokenizer = GPT3Tokenizer()
-    memory = VolatileMemory({'input':'', 'history':[]})
+    functions = FunctionRegistry.FunctionRegistry()
+    tokenizer = GPT3Tokenizer.GPT3Tokenizer()
+    memory = VolatileMemory.VolatileMemory({'input': '', 'history': []})
     max_tokens = 2000
 
     prompt_text = 'You are helpful, creative, clever, and very friendly. '
     PROMPT = Prompt([
         UserMessage(prompt_text),
-        ConversationHistory('history', .5),    # allow history to use up 1/2 the remaining token budget left after the prompt and input 
+        ConversationHistory('history', .5),
+        # allow history to use up 1/2 the remaining token budget left after the prompt and input
         UserMessage('{{$input}}')
     ])
 
-    async def render_messages_completion():
-        as_msgs = await PROMPT.renderAsMessages(memory, functions, tokenizer, max_tokens)
+    USER_PREFIX = 'user'
+    ASSISTANT_PREFIX = 'assistant'
+    def render_messages_completion():
+        as_msgs = PROMPT.renderAsMessages(memory, functions, tokenizer, max_tokens)
         msgs = []
         if not as_msgs.tooLong:
             msgs = as_msgs.output
         return msgs
 
+
     ### basic chat loop
     while True:
+        query = 'some query'
         memory.set('input', query)
-        msgs = asyncio.run(render_messages_completion())
-        response = ... your favorite llm api (model, msgs, ...)
+        msgs = render_messages_completion()
+        response = "some response" # call your favorite llm api(model, msgs, ...)
         print(response)
         history = memory.get('history')
-        history.append({'role':USER_PREFIX, 'content': query})
+        history.append({'role': USER_PREFIX, 'content': query})
         history.append({'role': ASSISTANT_PREFIX, 'content': response})
         memory.set('history', history)
- 
+        break
+
+    print(msgs)
+    # output:
+    # [{'role': 'user', 'content': 'You are helpful, creative, clever, and very friendly. '}, {'role': 'user', 'content': 'some query'}]
+
+
+# To run the tests:
+
+    python -m unittest tests/*.py
+

--- a/tests/ConversationHistoryTest.py
+++ b/tests/ConversationHistoryTest.py
@@ -1,11 +1,10 @@
-import aiounittest, unittest
+import unittest
 from promptrix.ConversationHistory import ConversationHistory
 from promptrix.VolatileMemory import VolatileMemory
 from promptrix.FunctionRegistry import FunctionRegistry
 from promptrix.GPT3Tokenizer import GPT3Tokenizer
-import asyncio
 
-class TestConversationHistory(aiounittest.AsyncTestCase):
+class TestConversationHistory(unittest.TestCase):
     def setUp(self):
         self.memory = VolatileMemory({
             "history": [
@@ -32,9 +31,9 @@ class TestConversationHistory(aiounittest.AsyncTestCase):
         self.assertEqual(section.assistantPrefix, "assistant")
         self.assertEqual(section.text_prefix, "")
 
-    async def test_renderAsMessages(self):
+    def test_renderAsMessages(self):
         section = ConversationHistory('history', 100)
-        rendered = await section.renderAsMessages(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsMessages(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, [
             { "role": "user", "content": "Hello" },
             { "role": "assistant", "content": "Hi" },

--- a/tests/FunctionRegistryTest.py
+++ b/tests/FunctionRegistryTest.py
@@ -1,7 +1,7 @@
 import unittest
-from FunctionRegistry import FunctionRegistry
-from VolatileMemory import VolatileMemory
-from GPT3Tokenizer import GPT3Tokenizer
+from promptrix.FunctionRegistry import FunctionRegistry
+from promptrix.VolatileMemory import VolatileMemory
+from promptrix.GPT3Tokenizer import GPT3Tokenizer
 
 class TestFunctionRegistry(unittest.TestCase):
     def test_constructor(self):

--- a/tests/PromptSectionBaseTest.py
+++ b/tests/PromptSectionBaseTest.py
@@ -1,4 +1,4 @@
-import aiounittest, unittest
+import unittest
 from promptrix.promptrixTypes import *
 from promptrix.PromptSectionBase import PromptSectionBase
 from promptrix.VolatileMemory import VolatileMemory
@@ -6,15 +6,15 @@ from promptrix.FunctionRegistry import FunctionRegistry
 from promptrix.GPT3Tokenizer import GPT3Tokenizer
 
 class TestSection(PromptSectionBase):
-    async def renderAsMessages(self, memory: PromptMemory, functions: PromptFunctions, tokenizer: Tokenizer, max_tokens: int):
+    def renderAsMessages(self, memory: PromptMemory, functions: PromptFunctions, tokenizer: Tokenizer, max_tokens: int):
         return self.return_messages([{'role': 'test', 'content': 'Hello Big World'}], 3, tokenizer, max_tokens)
 
 
 class MultiTestSection(PromptSectionBase):
-    async def renderAsMessages(self, memory: PromptMemory, functions: PromptFunctions, tokenizer: Tokenizer, max_tokens: int):
+    def renderAsMessages(self, memory: PromptMemory, functions: PromptFunctions, tokenizer: Tokenizer, max_tokens: int):
         return self.return_messages([{'role': 'test', 'content': 'Hello Big'}, {'role': 'test', 'content': 'World'}], 3, tokenizer, max_tokens)
 
-class TestPromptSectionBase(aiounittest.AsyncTestCase):
+class TestPromptSectionBase(unittest.TestCase):
     def setUp(self):
         self.memory = VolatileMemory()
         self.functions = FunctionRegistry()
@@ -27,46 +27,46 @@ class TestPromptSectionBase(aiounittest.AsyncTestCase):
         self.assertEqual(section.separator, "\n")
         self.assertEqual(section.text_prefix, "")
 
-    async def test_renderAsMessages(self):
+    def test_renderAsMessages(self):
         section = TestSection()
-        rendered = await section.renderAsMessages(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsMessages(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, [{'role': 'test', 'content': 'Hello Big World'}])
         self.assertEqual(rendered.length, 3)
         self.assertEqual(rendered.tooLong, False)
 
         section = TestSection(2)
-        rendered = await section.renderAsMessages(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsMessages(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, [{'role': 'test', 'content': 'Hello Big'}])
         self.assertEqual(rendered.length, 2)
         self.assertEqual(rendered.tooLong, False)
 
         section = TestSection(2)
-        rendered = await section.renderAsMessages(self.memory, self.functions, self.tokenizer, 1)
+        rendered = section.renderAsMessages(self.memory, self.functions, self.tokenizer, 1)
         self.assertEqual(rendered.output, [{'role': 'test', 'content': 'Hello Big'}])
         self.assertEqual(rendered.length, 2)
         self.assertEqual(rendered.tooLong, True)
 
         section = MultiTestSection(2)
-        rendered = await section.renderAsMessages(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsMessages(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, [{'role': 'test', 'content': 'Hello Big'}])
         self.assertEqual(rendered.length, 2)
         self.assertEqual(rendered.tooLong, False)
 
-    async def test_renderAsText(self):
+    def test_renderAsText(self):
         section = TestSection()
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, "Hello Big World")
         self.assertEqual(rendered.length, 3)
         self.assertEqual(rendered.tooLong, False)
 
         section = TestSection(4, True, "\n", "user: ")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, "user: Hello Big")
         self.assertEqual(rendered.length, 4)
         self.assertEqual(rendered.tooLong, False)
 
         section = TestSection(4, True, "\n", "user: ")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 1)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 1)
         self.assertEqual(rendered.output, "user: Hello Big")
         self.assertEqual(rendered.length, 4)
         self.assertEqual(rendered.tooLong, True)

--- a/tests/TemplateSectionTest.py
+++ b/tests/TemplateSectionTest.py
@@ -3,7 +3,6 @@ from promptrix.TemplateSection import TemplateSection
 from promptrix.VolatileMemory import VolatileMemory
 from promptrix.FunctionRegistry import FunctionRegistry
 from promptrix.GPT3Tokenizer import GPT3Tokenizer
-import asyncio
 
 class TestTemplateSection(unittest.TestCase):
     def setUp(self):
@@ -32,71 +31,71 @@ class TestTemplateSection(unittest.TestCase):
         self.assertEqual(section.required, False)
         self.assertEqual(section.separator, "\n")
 
-    async def test_renderAsMessages(self):
+    def test_renderAsMessages(self):
         section = TemplateSection("Hello World", "user")
-        rendered = await section.renderAsMessages(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsMessages(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, [{'role': 'user', 'content': 'Hello World'}])
         self.assertEqual(rendered.length, 2)
         self.assertEqual(rendered.tooLong, False)
 
         section = TemplateSection("Hello World", "user")
-        rendered = await section.renderAsMessages(self.memory, self.functions, self.tokenizer, 1)
+        rendered = section.renderAsMessages(self.memory, self.functions, self.tokenizer, 1)
         self.assertEqual(rendered.output, [{'role': 'user', 'content': 'Hello World'}])
         self.assertEqual(rendered.length, 2)
         self.assertEqual(rendered.tooLong, True)
 
-    async def test_renderAsText(self):
+    def test_renderAsText(self):
         section = TemplateSection("Hello World", "user")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, "Hello World")
         self.assertEqual(rendered.length, 2)
         self.assertEqual(rendered.tooLong, False)
 
         section = TemplateSection("Hello World", "user")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 1)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 1)
         self.assertEqual(rendered.output, "Hello World")
         self.assertEqual(rendered.length, 2)
         self.assertEqual(rendered.tooLong, True)
 
-    async def test_template_syntax(self):
+    def test_template_syntax(self):
         section = TemplateSection("Hello {{$foo}}", "user")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, "Hello bar")
         self.assertEqual(rendered.length, 2)
         self.assertEqual(rendered.tooLong, False)
 
         section = TemplateSection("Hello {{$foo}} {{test}}", "user")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, "Hello bar Hello World")
         self.assertEqual(rendered.length, 4 )
         self.assertEqual(rendered.tooLong, False)
 
         section = TemplateSection("Hello {{test2 World}}", "user")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, "Hello World")
         self.assertEqual(rendered.length, 2)
         self.assertEqual(rendered.tooLong, False)
 
         section = TemplateSection("Hello {{test2 'Big World'}}", "user")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, "Hello Big World")
         self.assertEqual(rendered.length, 3)
         self.assertEqual(rendered.tooLong, False)
 
         section = TemplateSection("Hello {{test2 `Big World`}}", "user")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, "Hello Big World")
         self.assertEqual(rendered.length, 3)
         self.assertEqual(rendered.tooLong, False)
 
         section = TemplateSection("Hello {{test3 'Big' World}}", "user")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, "Hello Big World")
         self.assertEqual(rendered.length, 3)
         self.assertEqual(rendered.tooLong, False)
 
         section = TemplateSection("{{}}", "user")
-        rendered = await section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
+        rendered = section.renderAsText(self.memory, self.functions, self.tokenizer, 100)
         self.assertEqual(rendered.output, "")
         self.assertEqual(rendered.length, 0)
         self.assertEqual(rendered.tooLong, False)
@@ -109,12 +108,7 @@ class TestTemplateSection(unittest.TestCase):
             section = TemplateSection("Hello {{test3 'Big}}", "user")
             self.assertTrue('Invalid template: Hello {{test3 \'Big}}' in str(context.exception))
 
-ts = TestTemplateSection()
-ts.setUp()
-ts.test_constructor()
-
 if __name__ == '__main__':
-    asyncio.run(ts.test_renderAsMessages())
-    asyncio.run(ts.test_renderAsText())
-    asyncio.run(ts.test_template_syntax())
-    
+    unittest.main()
+
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import os
+import sys
+PROJECT_PATH = os.getcwd()
+SOURCE_PATH = os.path.join(
+    PROJECT_PATH,"src"
+)
+sys.path.append(SOURCE_PATH)
+


### PR DESCRIPTION
Hi there,

This should fix the tests.

I don't know what to do with `functions = FunctionRegistry.FunctionRegistry()` it is rather ugly, but so is `from promptrix.FunctionRegistry import FunctionRegistry`.